### PR TITLE
Refactor resource creation target i.e. ECR repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -369,20 +369,7 @@ pipeline-check-resources: ## Check all the pipeline deployment supporting resour
 	# repos: DOCKER_REPOSITORIES
 
 pipeline-create-resources: ## Create all the pipeline deployment supporting resources - optional: PROFILE=[name]
-	profiles="$$(make project-list-profiles)"
-	# for each profile
-	#export PROFILE=$$profile
-	# TODO:
-	# Per AWS accoount, i.e. `nonprod` and `prod`
-	eval "$$(make aws-assume-role-export-variables)"
-	#make aws-dynamodb-create NAME=$(PROJECT_GROUP_SHORT)-$(PROJECT_NAME_SHORT)-deployment ATTRIBUTE_DEFINITIONS= KEY_SCHEMA=
-	#make secret-create NAME=$(PROJECT_GROUP_SHORT)-$(PROJECT_NAME_SHORT)-$(PROFILE)/deployment VARS=DB_PASSWORD,SMTP_PASSWORD,SLACK_WEBHOOK_URL
-	#make aws-s3-create NAME=$(PROJECT_GROUP_SHORT)-$(PROJECT_NAME_SHORT)-$(PROFILE)-deployment
-	#make ssl-request-certificate-prod SSL_DOMAINS_PROD
-	# Centralised, i.e. `mgmt`
-	eval "$$(make aws-assume-role-export-variables AWS_ACCOUNT_ID=$(AWS_ACCOUNT_ID_MGMT))"
-	#make docker-create-repository NAME=NAME_TEMPLATE_TO_REPLACE
-	#make aws-codeartifact-setup REPOSITORY_NAME=$(PROJECT_GROUP_SHORT)
+	make docker-create-repository NAME=dos-postcode-api
 
 pipeline-secret-scan:
 	make -s git-secrets-load


### PR DESCRIPTION
This make target is to create any AWS resources need for CI/CD operations. In this case, we have only an ECR repo. The expectation is that anything new will be added here. Please, could you also check the other projects and ensure that relevant entries are present? It also sets the right AWS access permission which otherwise setting it becomes another step that needs to be done manually and can be easily forgotten.

```make docker-create-repository NAME=dos-postcode-api```