### PR TITLE
SFD-5634 Use jenkins-slave instances for all jobs

### DIFF
--- a/build/jenkins/build/build.Jenkinsfile
+++ b/build/jenkins/build/build.Jenkinsfile
@@ -2,7 +2,9 @@ pipeline {
   /*
     Description: Development pipeline to build test push and deploy to nonprod
    */
-  agent any
+  agent {
+    label "jenkins-slave"
+  }
 
   environment {
     PROFILE = 'dev'

--- a/build/jenkins/demo/demo-deployment.Jenkinsfile
+++ b/build/jenkins/demo/demo-deployment.Jenkinsfile
@@ -3,7 +3,9 @@ pipeline {
     Description: Deployment pipeline for the Demo environment
    */
 
-  agent any
+  agent {
+    label "jenkins-slave"
+  }
 
   options {
     buildDiscarder(logRotator(daysToKeepStr: '7', numToKeepStr: '13'))

--- a/build/jenkins/dev/Dev_Deployment.Jenkinsfile
+++ b/build/jenkins/dev/Dev_Deployment.Jenkinsfile
@@ -2,7 +2,9 @@ pipeline {
   /*
     Description: Deployment pipeline
    */
-  agent any
+  agent {
+    label "jenkins-slave"
+  }
 
   options {
     buildDiscarder(logRotator(daysToKeepStr: '7', numToKeepStr: '13'))

--- a/build/jenkins/discard/burstDoublePeakPerformance.Jenkinsfile
+++ b/build/jenkins/discard/burstDoublePeakPerformance.Jenkinsfile
@@ -4,7 +4,9 @@ pipeline {
     Description: Deployment pipeline
    */
 
-  agent any
+  agent {
+    label "jenkins-slave"
+  }
 
   options {
     buildDiscarder(logRotator(daysToKeepStr: "7", numToKeepStr: "13"))

--- a/build/jenkins/discard/burstNominalPerformance.Jenkinsfile
+++ b/build/jenkins/discard/burstNominalPerformance.Jenkinsfile
@@ -4,7 +4,9 @@ pipeline {
     Description: Deployment pipeline
    */
 
-  agent any
+  agent {
+    label "jenkins-slave"
+  }
 
   options {
     buildDiscarder(logRotator(daysToKeepStr: "7", numToKeepStr: "13"))

--- a/build/jenkins/discard/burstPeakPerformance.Jenkinsfile
+++ b/build/jenkins/discard/burstPeakPerformance.Jenkinsfile
@@ -4,7 +4,9 @@ pipeline {
     Description: Deployment pipeline
    */
 
-  agent any
+  agent {
+    label "jenkins-slave"
+  }
 
   options {
     buildDiscarder(logRotator(daysToKeepStr: "7", numToKeepStr: "13"))

--- a/build/jenkins/discard/doublePeakPerformance.Jenkinsfile
+++ b/build/jenkins/discard/doublePeakPerformance.Jenkinsfile
@@ -4,7 +4,9 @@ pipeline {
     Description: Deployment pipeline
    */
 
-  agent any
+  agent {
+    label "jenkins-slave"
+  }
 
   options {
     buildDiscarder(logRotator(daysToKeepStr: "7", numToKeepStr: "13"))

--- a/build/jenkins/discard/nominalPerformance.Jenkinsfile
+++ b/build/jenkins/discard/nominalPerformance.Jenkinsfile
@@ -4,7 +4,9 @@ pipeline {
     Description: Deployment pipeline
    */
 
-  agent any
+  agent {
+    label "jenkins-slave"
+  }
 
   options {
     buildDiscarder(logRotator(daysToKeepStr: "7", numToKeepStr: "13"))

--- a/build/jenkins/discard/peakPerformance.Jenkinsfile
+++ b/build/jenkins/discard/peakPerformance.Jenkinsfile
@@ -4,7 +4,9 @@ pipeline {
     Description: Deployment pipeline
    */
 
-  agent any
+  agent {
+    label "jenkins-slave"
+  }
 
   options {
     buildDiscarder(logRotator(daysToKeepStr: '7', numToKeepStr: '13'))

--- a/build/jenkins/prod/Jenkinsfile-prod.deployment
+++ b/build/jenkins/prod/Jenkinsfile-prod.deployment
@@ -3,7 +3,9 @@ pipeline {
     Description: Deployment pipeline for the Prod environment
    */
 
-  agent any
+  agent {
+    label "jenkins-slave"
+  }
 
   options {
     buildDiscarder(logRotator(daysToKeepStr: "7", numToKeepStr: "13"))


### PR DESCRIPTION
On advice from Texas, switching agent from 'any' to 'jenkins-slave', should prevent builds happening on the Jenkins master node, freeing up resoruces.